### PR TITLE
Fixing anchor that points to Moment.js section

### DIFF
--- a/datetime.md
+++ b/datetime.md
@@ -10,7 +10,7 @@ tags: [Featurable]
 {: .-one-column}
 
 - [UNIX](#unix) - Used by Ruby, `date`, and more
-- [Moment.js](#moment-js) - Used by Moment.js, date-fns, and more
+- [Moment.js](#momentjs) - Used by Moment.js, date-fns, and more
 
 ## UNIX
 {: .-three-column}


### PR DESCRIPTION
The Moment.js' first `a` tag points to `moment-js` ID instead of `momentjs`. Just fixing it.

![72813996-ed43-4bd3-aaea-04c482fbe2de](https://user-images.githubusercontent.com/1407172/32403245-1b589ce2-c11c-11e7-947a-0d0d762f16ed.jpeg)
